### PR TITLE
Remove Android library leftover files

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,9 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.karczews.rxbroadcastreceiver">
-
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">library</string>
-</resources>


### PR DESCRIPTION
This is a pure Java library, no Android library project files are needed. I'm removing two files that were left when creating UtilsVerifier: AndroidManifest.xml and strings.xml