### PR TITLE
Add static mutable field check. Handling JaCoCo added fields in tests.

### DIFF
--- a/src/main/java/com/github/karczews/utilsverifier/Arrays2.java
+++ b/src/main/java/com/github/karczews/utilsverifier/Arrays2.java
@@ -1,0 +1,27 @@
+package com.github.karczews.utilsverifier;
+
+/**
+ * Internal tool that contains convenience methods to work with arrays.
+ */
+final class Arrays2 {
+    private Arrays2() {
+    }
+
+    /**
+     * Performs a check if the specified item is contained in the specified
+     * array.
+     *
+     * @param item will be checked if it's in the array
+     * @param array checked if contains the specified item
+     * @param <T> type of the array elements
+     * @return true if the array contains specified item, false otherwise
+     * @throws NullPointerException if the passed array is null
+     */
+    public static <T> boolean contains(final T item, final T[] array) {
+        for (int index = 0; index < array.length; index++) {
+            if (array[index] == item)
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/github/karczews/utilsverifier/Arrays2Test.java
+++ b/src/test/java/com/github/karczews/utilsverifier/Arrays2Test.java
@@ -1,0 +1,58 @@
+package com.github.karczews.utilsverifier;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class Arrays2Test {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void shouldThrowNullPointerExceptionForNullArray() {
+        expectedException.expect(NullPointerException.class);
+
+        final String[] array = null;
+        final String item = "";
+
+        Arrays2.contains(item, array);
+    }
+
+    @Test
+    public void shouldReturnFalseForEmptyArray() {
+        final String[] array = {};
+        final String item = "";
+
+        Assert.assertFalse(Arrays2.contains(item, array));
+    }
+
+    @Test
+    public void shouldReturnFalse() {
+        final String[] array = {"item1", "item2"};
+        final String item = "";
+
+        Assert.assertFalse(Arrays2.contains(item, array));
+    }
+
+    @Test
+    public void shouldReturnFalseForNullItem() {
+        final String[] array = {"item1", "item2"};
+        final String item = null;
+
+        Assert.assertFalse(Arrays2.contains(item, array));
+    }
+
+    @Test
+    public void shouldReturnTrue() {
+        final String[] array = {"item1", "item2"};
+        final String item = "item1";
+
+        Assert.assertTrue(Arrays2.contains(item, array));
+    }
+
+    @Test
+    public void verifyArraysTool() {
+        UtilsVerifier.forClass(Arrays2.class).verify();
+    }
+}

--- a/src/test/java/com/github/karczews/utilsverifier/UtilsVerifierTest.java
+++ b/src/test/java/com/github/karczews/utilsverifier/UtilsVerifierTest.java
@@ -15,28 +15,48 @@ package com.github.karczews.utilsverifier;
 
 import com.github.karczews.utilsverifier.subjects.AbstractClass;
 import com.github.karczews.utilsverifier.subjects.DefaultConstructor;
+import com.github.karczews.utilsverifier.subjects.ImmutableStaticFields;
 import com.github.karczews.utilsverifier.subjects.InstanceFields;
 import com.github.karczews.utilsverifier.subjects.InstanceMethods;
 import com.github.karczews.utilsverifier.subjects.MultipleConstructors;
+import com.github.karczews.utilsverifier.subjects.MutableStaticFields;
 import com.github.karczews.utilsverifier.subjects.NonFinalClass;
 import com.github.karczews.utilsverifier.subjects.NonPrivateConstructor;
 import com.github.karczews.utilsverifier.subjects.ThrowingConstructor;
 import com.github.karczews.utilsverifier.subjects.WellFormed;
-
+import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.StringContains.containsString;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
-
-import static org.hamcrest.core.AllOf.allOf;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 
 public class UtilsVerifierTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void shouldFailOnMutableStaticFields() {
+        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(containsString("staticInt"));
+
+        suppressedVerifier(MutableStaticFields.class)
+                .suppressMutableStaticFieldsCheck(false)
+                .verify();
+    }
+
+    @Test
+    public void shouldPassOnMutableStaticFields() {
+        suppressedVerifier(ImmutableStaticFields.class)
+                .suppressMutableStaticFieldsCheck(false)
+                .verify();
+
+        // due to complex condition two asserts in one test
+        // to not create confusion with strange test name
+        suppressedVerifier(InstanceFields.class)
+                .suppressMutableStaticFieldsCheck(false)
+                .verify();
+    }
 
     @Test
     public void shouldFailOnNonFinalClassVerification() {
@@ -152,6 +172,7 @@ public class UtilsVerifierTest {
                 .suppressOnlyOneConstructorCheck(true)
                 .suppressPrivateConstructorCheck(true)
                 .suppressInstanceFieldCheck(true)
-                .suppressInstanceMethodCheck(true);
+                .suppressInstanceMethodCheck(true)
+                .suppressMutableStaticFieldsCheck(true);
     }
 }

--- a/src/test/java/com/github/karczews/utilsverifier/subjects/ImmutableStaticFields.java
+++ b/src/test/java/com/github/karczews/utilsverifier/subjects/ImmutableStaticFields.java
@@ -1,0 +1,8 @@
+package com.github.karczews.utilsverifier.subjects;
+
+public final class ImmutableStaticFields {
+    private static final int staticInt = 0;
+
+    private ImmutableStaticFields(){
+    }
+}

--- a/src/test/java/com/github/karczews/utilsverifier/subjects/MutableStaticFields.java
+++ b/src/test/java/com/github/karczews/utilsverifier/subjects/MutableStaticFields.java
@@ -1,0 +1,8 @@
+package com.github.karczews.utilsverifier.subjects;
+
+public final class MutableStaticFields {
+    private static int staticInt;
+
+    private MutableStaticFields() {
+    }
+}


### PR DESCRIPTION
Added static mutable fields check.

This caused issues with JaCoCo, as it adds "$jacocoData" field to the tested class. This prevented tests from passing as with JaCoCo enabled there was always a static mutable field present.

I considered a workaround through Gradle configuration. I failed to configure it properly. It's worth to explore the idea. If we could disable JaCoCo for `MutableStaticFields` class then the ugly workaround in the code would not be needed.