### PR TITLE
Removing all API calls not compatible with Java 1.5

### DIFF
--- a/src/main/java/com/github/karczews/utilsverifier/UtilsVerifier.java
+++ b/src/main/java/com/github/karczews/utilsverifier/UtilsVerifier.java
@@ -198,8 +198,8 @@ public final class UtilsVerifier<T> {
             if (!suppressPrivateConstructorCheck && !Modifier.isPrivate(constructor.getModifiers())) {
                 throw new AssertionError("Constructor should be private");
             }
-        } catch (final NoSuchMethodException noSuchMethod) {
-            throw new AssertionError(classUnderTest.getSimpleName() + " has no constructor", noSuchMethod);
+        } catch (final NoSuchMethodException ignore) {
+            throw new AssertionError(classUnderTest.getSimpleName() + " has no constructor");
         }
 
         try {
@@ -213,7 +213,7 @@ public final class UtilsVerifier<T> {
                 throw new AssertionError("expected exception: " + expectedConstructorException.getName() +
                         " got: " + e.getTargetException().getClass().getName());
             }
-        } catch (final ReflectiveOperationException e) {
+        } catch (final Exception e) {
             throw new IllegalStateException(e);
         }
     }

--- a/src/test/java/com/github/karczews/utilsverifier/UtilsVerifierTest.java
+++ b/src/test/java/com/github/karczews/utilsverifier/UtilsVerifierTest.java
@@ -20,6 +20,7 @@ import com.github.karczews.utilsverifier.subjects.InstanceFields;
 import com.github.karczews.utilsverifier.subjects.InstanceMethods;
 import com.github.karczews.utilsverifier.subjects.MultipleConstructors;
 import com.github.karczews.utilsverifier.subjects.MutableStaticFields;
+import com.github.karczews.utilsverifier.subjects.NoConstructor;
 import com.github.karczews.utilsverifier.subjects.NonFinalClass;
 import com.github.karczews.utilsverifier.subjects.NonPrivateConstructor;
 import com.github.karczews.utilsverifier.subjects.ThrowingConstructor;
@@ -89,8 +90,9 @@ public class UtilsVerifierTest {
     }
 
     @Test
-    public void shouldFailWhenNoConstructor() {
+    public void shouldFailWhenOnlyADefaultPublicConstructor() {
         expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(containsString("should be private"));
 
         suppressedVerifier(DefaultConstructor.class)
                 .suppressPrivateConstructorCheck(false)
@@ -103,6 +105,16 @@ public class UtilsVerifierTest {
         expectedException.expectMessage(containsString("should be private"));
 
         suppressedVerifier(NonPrivateConstructor.class)
+                .suppressPrivateConstructorCheck(false)
+                .verify();
+    }
+
+    @Test
+    public void shouldFailWhenNoConstructor() {
+        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(containsString("has no constructor"));
+
+        suppressedVerifier(NoConstructor.class)
                 .suppressPrivateConstructorCheck(false)
                 .verify();
     }

--- a/src/test/java/com/github/karczews/utilsverifier/subjects/NoConstructor.java
+++ b/src/test/java/com/github/karczews/utilsverifier/subjects/NoConstructor.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2017-present, UtilsVerifier Contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.karczews.utilsverifier.subjects;
+
+public interface NoConstructor {
+}


### PR DESCRIPTION
As discussed in https://github.com/karczews/UtilsVerifier/issues/7

- removing a call to `AssertionError` constructor added in Java 1.7
- removing usage of `ReflectiveOperationException` 

The last one is a bit problematic in terms of tests. Although it was possible to change it to two separate catches:

```java
} catch (final IllegalAccessException e) {
    throw new IllegalStateException(e);
} catch (final InstantiationException e) {
    throw new IllegalStateException(e);
}
```

I cannot get a full 100% code coverage now. I don't know yet how to get an `IllegalAccessException` from the call to `constructor.newInstance();`. If we want to have full coverage this needs a bit of looking.

